### PR TITLE
Support for bitprophet's paramiko fork, ssh

### DIFF
--- a/pushy/transport/ssh.py
+++ b/pushy/transport/ssh.py
@@ -36,7 +36,10 @@ is_windows = (sys.platform == "win32")
 try:
     import paramiko
 except ImportError:
-    paramiko = None
+    try:
+        import ssh as paramiko
+    except ImportError:
+        paramiko = None
 
 if paramiko:
     class WrappedChannelFile(object):


### PR DESCRIPTION
Paramiko has been forked to "ssh" (https://github.com/bitprophet/ssh). This change adds support if the python-ssh fork is being used instead of paramiko.
