### PR TITLE
Catch I/O Errors on ValueError exception

### DIFF
--- a/pushy/protocol/baseconnection.py
+++ b/pushy/protocol/baseconnection.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2008, 2011 Andrew Wilkins <axwalk@gmail.com>
-# 
+#
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
 # files (the "Software"), to deal in the Software without
@@ -8,10 +8,10 @@
 # copies of the Software, and to permit persons to whom the
 # Software is furnished to do so, subject to the following
 # conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 # EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
 # OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -268,6 +268,12 @@ Proxied Object Count: %r
                         self.__handle(m)
                 except IOError:
                     return
+                except ValueError as err:
+                    # File could already be closed
+                    if err.message == 'I/O operation on closed file':
+                        return
+                    # re-raise if its something non-IO
+                    raise
         finally:
             pushy.util.logger.debug("Leaving serve_forever")
 


### PR DESCRIPTION
We are seeing some errors from threads that are not able to write to the stream because the connection is closing the file descriptors before the threads are joined (as seen in `protocol.ssh.NativePopen.close` ).

The connection object is already catching `IOError` but `ValueError` can also be raised for some IO Errors as well. 

I am making sure that we only catch that exact issue (`'I/O operation on closed file'`) otherwise the exception is re-raised (if for whatever reason a different ValueError is raised).
